### PR TITLE
Fix for issue #10

### DIFF
--- a/OpenControls.Wpf.DockManager/DockPaneManager.cs
+++ b/OpenControls.Wpf.DockManager/DockPaneManager.cs
@@ -164,6 +164,7 @@ namespace OpenControls.Wpf.DockManager
             floatingPane.Top = cursorPositionOnScreen.Y - 30;
             floatingPane.Width = dockPane.ActualWidth;
             floatingPane.Height = dockPane.ActualHeight;
+            floatingPane.Show();
         }
 
         private void DockPane_FloatTabRequest(object sender, EventArgs e)

--- a/OpenControls.Wpf.DockManager/FloatingPaneManager.cs
+++ b/OpenControls.Wpf.DockManager/FloatingPaneManager.cs
@@ -82,6 +82,7 @@ namespace OpenControls.Wpf.DockManager
             newFloatingPane.Left = left;
             newFloatingPane.Top = top;
             newFloatingPane.IViewContainer.AddUserControl(userControl);
+            newFloatingPane.Show();
 
             return floatingPane;
         }

--- a/OpenControls.Wpf.DockManager/FloatingPaneManager.cs
+++ b/OpenControls.Wpf.DockManager/FloatingPaneManager.cs
@@ -464,7 +464,6 @@ namespace OpenControls.Wpf.DockManager
             floatingPane.EndDrag += FloatingPane_EndDrag;
             // Ensure the window remains on top of the main window
             floatingPane.Owner = Application.Current.MainWindow;
-            floatingPane.Show();
         }
 
         private void FloatingPane_GotFocus(object sender, RoutedEventArgs e)
@@ -516,6 +515,7 @@ namespace OpenControls.Wpf.DockManager
             newFloatingPane.Top = cursorPositionOnScreen.Y - 30;
             newFloatingPane.Width = floatingPane.ActualWidth;
             newFloatingPane.Height = floatingPane.ActualHeight;
+            newFloatingPane.Show();
         }
 
         #region IFloatingPaneManager


### PR DESCRIPTION
Minimal solution to issue #10 through correction of FloatingPaneManager.RegisterFloatingPane.

One moment. This method is called from a couple of methods with name Show

public void Show(FloatingDocumentPaneGroup floatingDocumentPaneGroup)
public void Show(FloatingToolPaneGroup floatingToolPaneGroup)

I think these methods need to rename to RegisterFloatingPane or AddFloatingPane ...