### PR TITLE
Fix the issue that "zMin + zMax = 0" is required.

### DIFF
--- a/OpenControls.WinForms.SurfacePlotterDemo/Form1.cs
+++ b/OpenControls.WinForms.SurfacePlotterDemo/Form1.cs
@@ -62,8 +62,8 @@ namespace OpenControls.WinForms.SurfacePlotterDemo
             const int YCount = 50;
             const int XCount = 50;
             int counter = 0;
-            float zMax = 150;
-            float zMin = -150;
+            float zMax = 259;
+            float zMin = -73.98f;
             float scale = 2f * (float)System.Math.PI / (float)XCount;
 
             List<List<float>> srcData = new List<List<float>>();

--- a/OpenControls.Wpf.SurfacePlot/SurfacePlotterControl.cs
+++ b/OpenControls.Wpf.SurfacePlot/SurfacePlotterControl.cs
@@ -778,10 +778,20 @@ namespace OpenControls.Wpf.SurfacePlot
              * Doing this after the surface reduces issues with hidden lines being visible through the surface. 
              */
 
-            float zGridRange = (float)(_axisScaling * (_zAxisLabels.MaxValue - _zAxisLabels.MinValue) * ZScale);
+            /*
+             * The orginal code
+             * 
+              float zGridRange = (float)(_axisScaling * (_zAxisLabels.MaxValue - _zAxisLabels.MinValue) * ZScale);
+              float zGridInc = zGridRange / (float)(_zAxisLabels.Labels.Count - 1);
+              float zMin = -zGridRange / 2;
+              float zMax = -zMin;
+             */
+            float zLen = _zAxisLabels.MaxValue - _zAxisLabels.MinValue;//Compute zLen = zMax - zMin
+            float zGridRange = (float)(_axisScaling * zLen * ZScale);//Replace zMax - zMin with zLen
             float zGridInc = zGridRange / (float)(_zAxisLabels.Labels.Count - 1);
-            float zMin = -zGridRange / 2;
-            float zMax = -zMin;
+            float zMin = zGridRange * (_zAxisLabels.MinValue / zLen);//Compute current zMin by its length ratio
+            float zMax = zGridRange * (_zAxisLabels.MaxValue / zLen);//Compute current zMax by its length ratio
+            
             float xMax = _axisScaling * (_lineData.Count - 1);
             float yMax = _axisScaling * (_lineData[0].Count - 1);
 


### PR DESCRIPTION
Fix the issue that "zMin + zMax = 0" is required, or it would display wrong surface charts.
When zMin + zMax != 0, the surface charts would float over zMax or sink below zMin.